### PR TITLE
textarea to allow additional line items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 .idea/
+.DS_Store
 
 /vendor/
 /.php-cs-fixer.cache

--- a/assets/js/publisher-collective-ads-txt.js
+++ b/assets/js/publisher-collective-ads-txt.js
@@ -1,0 +1,3 @@
+window.onload = function (){
+    alert('hekki');
+}

--- a/assets/js/publisher-collective-ads-txt.js
+++ b/assets/js/publisher-collective-ads-txt.js
@@ -1,3 +1,0 @@
-window.onload = function (){
-    alert('hekki');
-}

--- a/assets/php/settings/PublisherCollectiveSettings.php
+++ b/assets/php/settings/PublisherCollectiveSettings.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Class PublisherCollectiveSettings
+ */
+class PublisherCollectiveSettings
+{
+    /**
+     * @var string
+     */
+    const PAGE_NAME = 'publisher-collective-adstxt-settings';
+
+    /**
+     * @var string
+     */
+    const PAGE_TITLE = 'publisher collective adstxt settings';
+
+    /**
+     * @var array
+     */
+    const RESULT_STATUS = [
+        'ERRORED' => 'error',
+        'SUCCESS' => 'success',
+        'WARNING' => 'warning',
+        'INFO' => 'info'
+    ];
+
+    /**
+     * @var array
+     */
+    const RESULT_MESSAGES = [
+        'ERRORED' => 'Additional line items should not be blank',
+        'SUCCESS' => 'Successfully undated',
+        'WARNING' => 'warning',
+        'INFO' => 'info'
+    ];
+
+    /**
+     * @var array
+     */
+    private $resultMessage = [
+        'status' => null,
+        'message' => ''
+    ];
+
+    public function init()
+    {
+        add_action('admin_menu', array($this, 'initiateAdminMenu'));
+        add_action('admin_init', array($this, 'initiateAdminFields'));
+        $this->handleSubmission();
+    }
+
+    public function initiateAdminMenu()
+    {
+        add_menu_page(self::PAGE_NAME,
+            'Ads txt', 'administrator',
+            self::PAGE_NAME, array($this, 'renderAdsTxtSettingsPageMenu'), 'dashicons-admin-settings', 6);
+    }
+
+    public function initiateAdminFields()
+    {
+        add_settings_error(
+            'pub_col_settings_error_field_key', // whatever you registered in `register_setting
+            'pub_col_settings_error_field', // doesn't really mater
+            __($this->resultMessage['message'], 'wpse'),
+            $this->resultMessage['status']
+        );
+
+        register_setting(
+            self::PAGE_NAME,
+            'pub_col_settings_error_field_key'
+        );
+
+
+        add_settings_section(
+            // ID used to identify this section and with which to register options
+            'pub_col_settings_error_section',
+            // Title to be displayed on the administration page
+            '',
+            // Callback used to render the description of the section
+            array($this, 'renderErrorMessages'),
+            // Page on which to add this section of options
+            self::PAGE_NAME
+        );
+
+
+        add_settings_section(
+        // ID used to identify this section and with which to register options
+            'additional_line_items_section',
+            // Title to be displayed on the administration page
+            self::PAGE_TITLE,
+            // Callback used to render the description of the section
+            array($this, 'featuresSectionDescription'),
+            // Page on which to add this section of options
+            self::PAGE_NAME
+        );
+
+        add_settings_field(
+            'additional_line_items_field',
+            'Additional line items',
+            array($this, 'addThemeBodyFunction'),
+            self::PAGE_NAME,
+            'additional_line_items_section'
+        );
+
+        register_setting(
+            self::PAGE_NAME,
+            'additional_line_items_field'
+        );
+    }
+
+    public function renderAdsTxtSettingsPageMenu()
+    {
+        settings_fields(self::PAGE_NAME);
+        do_settings_sections(self::PAGE_NAME);
+    }
+
+    public function featuresSectionDescription()
+    {
+        echo 'Edit settings on your ads txt plugin';
+    }
+
+    public function renderErrorMessages()
+    {
+        if (!empty($this->resultMessage['status'])) {
+            include(PUB_COL_PLUGIN_DIR . 'assets/templates/additional-line-items-error-messages.php');
+        }
+    }
+
+    public function addThemeBodyFunction()
+    {
+        include(PUB_COL_PLUGIN_DIR . 'assets/templates/additional-line-items-form.php');
+    }
+
+    public function handleSubmission()
+    {
+        if (isset($_POST['pc-ads-txt-extra-params'])) {
+            if (empty($_POST['pc-ads-txt-extra-params'])) {
+                $this->resultMessage['status'] = self::RESULT_STATUS['ERRORED'];
+                $this->resultMessage['message'] = self::RESULT_MESSAGES['ERRORED'];
+                return;
+            }
+            $adsTxtExtraParams = $_POST['pc-ads-txt-extra-params'];
+            update_option('pc-ads-txt-extra-params', $adsTxtExtraParams);
+            $this->resultMessage['status'] = self::RESULT_STATUS['SUCCESS'];
+            $this->resultMessage['message'] = self::RESULT_MESSAGES['SUCCESS'];
+        }
+    }
+}

--- a/assets/php/settings/PublisherCollectiveSettings.php
+++ b/assets/php/settings/PublisherCollectiveSettings.php
@@ -13,7 +13,7 @@ class PublisherCollectiveSettings
     /**
      * @var string
      */
-    const PAGE_TITLE = 'publisher collective adstxt settings';
+    const PAGE_TITLE = 'Publisher Collective ads.txt settings';
 
     /**
      * @var array
@@ -60,8 +60,8 @@ class PublisherCollectiveSettings
     public function initiateAdminFields()
     {
         add_settings_error(
-            'pub_col_settings_error_field_key', // whatever you registered in `register_setting
-            'pub_col_settings_error_field', // doesn't really mater
+            'pub_col_settings_error_field_key',
+            'pub_col_settings_error_field',
             __($this->resultMessage['message'], 'wpse'),
             $this->resultMessage['status']
         );
@@ -135,11 +135,6 @@ class PublisherCollectiveSettings
     public function handleSubmission()
     {
         if (isset($_POST['pc-ads-txt-extra-params'])) {
-            if (empty($_POST['pc-ads-txt-extra-params'])) {
-                $this->resultMessage['status'] = self::RESULT_STATUS['ERRORED'];
-                $this->resultMessage['message'] = self::RESULT_MESSAGES['ERRORED'];
-                return;
-            }
             $adsTxtExtraParams = $_POST['pc-ads-txt-extra-params'];
             update_option('pc-ads-txt-extra-params', $adsTxtExtraParams);
             $this->resultMessage['status'] = self::RESULT_STATUS['SUCCESS'];

--- a/assets/templates/additional-line-items-error-messages.php
+++ b/assets/templates/additional-line-items-error-messages.php
@@ -1,0 +1,3 @@
+<br/>
+<?php settings_errors('pub_col_settings_error_field_key'); ?>
+<br/>

--- a/assets/templates/additional-line-items-form.php
+++ b/assets/templates/additional-line-items-form.php
@@ -1,0 +1,9 @@
+<form method="post">
+    <div>
+        <textarea name="pc-ads-txt-extra-params" rows="8" cols="50"><?php echo get_option('pc-ads-txt-extra-params', ''); ?></textarea>
+    </div>
+    <div>
+        <br />
+        <input type="submit" class="button button-primary" value="Update">
+    </div>
+</form>

--- a/publisher-collective.php
+++ b/publisher-collective.php
@@ -13,7 +13,11 @@ Author URI: https://www.pathfindermediagroup.com
 License: GPL-3
 */
 
+define('PUB_COL_PLUGIN_DIR', plugin_dir_path(__FILE__));
 defined('ABSPATH') || exit;
+
+require_once PUB_COL_PLUGIN_DIR . 'assets/php/settings/PublisherCollectiveSettings.php';
+
 add_action('plugins_loaded', 'PublisherCollective::setup');
 
 final class PublisherCollective
@@ -23,6 +27,7 @@ final class PublisherCollective
     public static function setup(): void
     {
         $self = new self();
+        (new PublisherCollectiveSettings())->init();
         add_action('wp', [$self, 'pc_cronstarter_activation']);
         add_action('fetch-publisher-collective-ads-txt', [$self, 'fetch_ads_txt']);
         add_filter('query_vars', [$self, 'display_pc_ads_txt']);
@@ -30,7 +35,7 @@ final class PublisherCollective
 
     public static function pc_cronstarter_activation(): void
     {
-        if (! wp_next_scheduled('fetch-publisher-collective-ads-txt')) {
+        if (!wp_next_scheduled('fetch-publisher-collective-ads-txt')) {
             wp_schedule_event(time(), 'daily', 'fetch-publisher-collective-ads-txt');
         }
     }
@@ -73,7 +78,7 @@ final class PublisherCollective
 
     private static function getDomain(): ?string
     {
-        if (! empty(get_home_url())) {
+        if (!empty(get_home_url())) {
             return rtrim(str_replace(['https://', 'http://', 'www.'], '', get_home_url()), '/');
         }
 
@@ -86,13 +91,16 @@ final class PublisherCollective
         if (empty($data) || $renew) {
             $serverName = self::getServerName();
             $data = wp_remote_retrieve_body(wp_remote_get(
-                $serverName ? (self::ADS_TXT_URL_PREFIX.$serverName) : self::ADS_TXT_URL_PREFIX
+                $serverName ? (self::ADS_TXT_URL_PREFIX . $serverName) : self::ADS_TXT_URL_PREFIX
             ));
             if ($data !== false) {
                 set_transient('publisher_collective_ads_txt', $data, 86400);
             }
         }
-
+        if (!empty($data)) {
+            $adsTxtExtraParams = get_option('pc-ads-txt-extra-params', null);
+            $data .= $adsTxtExtraParams;
+        }
         return $data;
     }
 }

--- a/publisher-collective.php
+++ b/publisher-collective.php
@@ -99,7 +99,7 @@ final class PublisherCollective
         }
         if (!empty($data)) {
             $adsTxtExtraParams = get_option('pc-ads-txt-extra-params', null);
-            $data .= $adsTxtExtraParams;
+            $data .= PHP_EOL.$adsTxtExtraParams;
         }
         return $data;
     }

--- a/tests/assets/php/settings/PublisherCollectiveSettingsTest.php
+++ b/tests/assets/php/settings/PublisherCollectiveSettingsTest.php
@@ -2,26 +2,6 @@
 
 declare(strict_types=1);
 
-if (!function_exists('dump')) {
-    function dump($object = "", $echo = true)
-    {
-        $output = "<pre style='background-color: #0c0c0c; color: #0bbd0b; padding:20px;'>" . print_r($object, true) . "</pre>";
-        if ($echo) {
-            echo $output;
-            return;
-        }
-        return $output;
-    }
-}
-
-if (!function_exists('dd')) {
-    function dd($object = "")
-    {
-        dump($object);
-        die;
-    }
-}
-
 use PHPUnit\Framework\TestCase;
 
 include __DIR__.'/../../../publisher-collective_mock_functions.php';

--- a/tests/assets/php/settings/PublisherCollectiveSettingsTest.php
+++ b/tests/assets/php/settings/PublisherCollectiveSettingsTest.php
@@ -32,15 +32,15 @@ final class PublisherCollectiveSettingsTest extends TestCase
         $this->assertEquals($resultMessage['message'], 'Successfully undated');
     }
 
-    public function testErrorReceivedIfExtraParamsEmpty(): void
+    public function testSuccessReceivedIfExtraParamsEmpty(): void
     {
         $_POST['pc-ads-txt-extra-params'] = '';
         $publisherCollectiveSettings = new PublisherCollectiveSettings();
         $this->getProperty($publisherCollectiveSettings, 'resultMessage');
         $publisherCollectiveSettings->handleSubmission();
         $resultMessage = $this->getProperty($publisherCollectiveSettings, 'resultMessage');
-        $this->assertEquals($resultMessage['status'], $publisherCollectiveSettings::RESULT_STATUS['ERRORED']);
-        $this->assertEquals($resultMessage['message'], $publisherCollectiveSettings::RESULT_MESSAGES['ERRORED']);
+        $this->assertEquals($resultMessage['status'], $publisherCollectiveSettings::RESULT_STATUS['SUCCESS']);
+        $this->assertEquals($resultMessage['message'], $publisherCollectiveSettings::RESULT_MESSAGES['SUCCESS']);
     }
 
     public function testNULLReceivedIfExtraParamsNOTSent(): void

--- a/tests/assets/php/settings/PublisherCollectiveSettingsTest.php
+++ b/tests/assets/php/settings/PublisherCollectiveSettingsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+if (!function_exists('dump')) {
+    function dump($object = "", $echo = true)
+    {
+        $output = "<pre style='background-color: #0c0c0c; color: #0bbd0b; padding:20px;'>" . print_r($object, true) . "</pre>";
+        if ($echo) {
+            echo $output;
+            return;
+        }
+        return $output;
+    }
+}
+
+if (!function_exists('dd')) {
+    function dd($object = "")
+    {
+        dump($object);
+        die;
+    }
+}
+
+use PHPUnit\Framework\TestCase;
+
+include __DIR__.'/../../../publisher-collective_mock_functions.php';
+include __DIR__.'/../../../../assets/php/settings/PublisherCollectiveSettings.php';
+
+/**
+ * Class PublisherCollectiveSettingsTest
+ * @runTestsInSeparateProcesses
+ */
+final class PublisherCollectiveSettingsTest extends TestCase
+{
+    public static function getProperty($object, $property)
+    {
+        $reflectedClass = new \ReflectionClass($object);
+        $reflection = $reflectedClass->getProperty($property);
+        $reflection->setAccessible(true);
+        return $reflection->getValue($object);
+    }
+
+    public function testSuccessReceivedIfExtraParamsSent(): void
+    {
+        $_POST['pc-ads-txt-extra-params'] = 'some-value';
+        $publisherCollectiveSettings = new PublisherCollectiveSettings();
+        $this->getProperty($publisherCollectiveSettings, 'resultMessage');
+        $publisherCollectiveSettings->handleSubmission();
+        $resultMessage = $this->getProperty($publisherCollectiveSettings, 'resultMessage');
+        $this->assertEquals($resultMessage['status'], 'success');
+        $this->assertEquals($resultMessage['message'], 'Successfully undated');
+    }
+
+    public function testErrorReceivedIfExtraParamsEmpty(): void
+    {
+        $_POST['pc-ads-txt-extra-params'] = '';
+        $publisherCollectiveSettings = new PublisherCollectiveSettings();
+        $this->getProperty($publisherCollectiveSettings, 'resultMessage');
+        $publisherCollectiveSettings->handleSubmission();
+        $resultMessage = $this->getProperty($publisherCollectiveSettings, 'resultMessage');
+        $this->assertEquals($resultMessage['status'], $publisherCollectiveSettings::RESULT_STATUS['ERRORED']);
+        $this->assertEquals($resultMessage['message'], $publisherCollectiveSettings::RESULT_MESSAGES['ERRORED']);
+    }
+
+    public function testNULLReceivedIfExtraParamsNOTSent(): void
+    {
+        $publisherCollectiveSettings = new PublisherCollectiveSettings();
+        $this->getProperty($publisherCollectiveSettings, 'resultMessage');
+        $publisherCollectiveSettings->handleSubmission();
+        $resultMessage = $this->getProperty($publisherCollectiveSettings, 'resultMessage');
+        $this->assertEquals($resultMessage['status'], null);
+        $this->assertEquals($resultMessage['message'], '');
+    }
+}

--- a/tests/publisher-collective_mock_functions.php
+++ b/tests/publisher-collective_mock_functions.php
@@ -20,6 +20,18 @@ if (! function_exists('add_action')) {
     }
 }
 
+if (! function_exists('plugin_dir_path')) {
+    function plugin_dir_path()
+    {
+    }
+}
+
+if (! function_exists('update_option')) {
+    function update_option()
+    {
+    }
+}
+
 if (! defined('ABSPATH')) {
     define('ABSPATH', __DIR__.'/');
 }


### PR DESCRIPTION
Input field added to the wordpress plugin to allow addtional line items to be added to the ads.txt

1. Portfolio was added to the menu
2. Textarea was added to the settings page

![image](https://user-images.githubusercontent.com/84023099/173832791-70b5cc29-a716-46fe-a5a7-f1f11fa62862.png)


Success page

![image](https://user-images.githubusercontent.com/84023099/173833093-1bc2a965-9821-4f59-aac6-57215f859d63.png)

**Blank entries can be submitted**